### PR TITLE
Adds CODEOWNERS and a first, probably broken, Github Action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ljnelson

--- a/.github/workflows/mvn-verify.yaml
+++ b/.github/workflows/mvn-verify.yaml
@@ -1,0 +1,22 @@
+name: 'Action: Maven Verify'
+run-name: 'Action Run: Maven Verify'
+on:
+  - 'push'
+jobs:
+  job-mvn-verify:
+    name: 'Maven Verify'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - id: 'checkout'
+        name: 'Step: Checkout'
+        uses: 'actions/checkout@v4'
+      - id: 'setup-java'
+        name: 'Step: Set Up Java and Maven'
+        uses: 'actions/setup-java@3'
+        with:
+          cache: 'maven'
+          distribution: 'oracle'
+          java-version: '11'
+      - id: 'mvn-verify'
+        name: 'Step: Maven Verify'
+        run: 'mvn -B -Dorg.slf4j.simpleLogger.defaultLogLevel=info verify'


### PR DESCRIPTION
Attempts to add a first cut at a Github action that will, after setup ceremonies, run `mvn -B verify` on every push.