### PR TITLE
Gives Github no permissions at all in mvn-verify.yaml.

### DIFF
--- a/.github/workflows/mvn-verify.yaml
+++ b/.github/workflows/mvn-verify.yaml
@@ -5,6 +5,7 @@ on:
 jobs:
   job-mvn-verify:
     name: 'Maven Verify'
+    permissions: {}
     runs-on: 'ubuntu-latest'
     steps:
       - id: 'checkout'

--- a/.github/workflows/mvn-verify.yaml
+++ b/.github/workflows/mvn-verify.yaml
@@ -1,6 +1,7 @@
 name: 'Action: Maven Verify'
 run-name: 'Action Run: Maven Verify'
 on:
+  - 'pull_request'
   - 'push'
 jobs:
   job-mvn-verify:


### PR DESCRIPTION
This pull request removes permissions entirely from the `job-mvn-verify` job (`Maven Verify`). They do not seem to be needed.